### PR TITLE
Auto detect USB / inserting/removing of cameras to do a refresh 

### DIFF
--- a/QCamera/QCAppDelegate.swift
+++ b/QCamera/QCAppDelegate.swift
@@ -11,7 +11,14 @@ import AVKit
 import AVFoundation
 
 @NSApplicationMain
-class QCAppDelegate: NSObject, NSApplicationDelegate {
+class QCAppDelegate: NSObject, NSApplicationDelegate, QCUsbWatcherDelegate {
+
+    let usb = QCUsbWatcher()
+    func deviceCountChanged() {
+        self.detectVideoDevices()
+        self.startCaptureWithVideoDevice(defaultDevice: selectedDeviceIndex)
+    }
+
     
     @IBOutlet weak var window: NSWindow!
     @IBOutlet weak var selectSourceMenu: NSMenuItem!
@@ -26,7 +33,8 @@ class QCAppDelegate: NSObject, NSApplicationDelegate {
     var isBorderless: Bool = false;
     var defaultBorderStyle: NSWindow.StyleMask = NSWindow.StyleMask.closable;
     var windowTitle = "Quick Camera";
-    var defaultDeviceIndex: Int = 0;
+    let defaultDeviceIndex: Int = 0;
+    var selectedDeviceIndex: Int = 0
     
     var devices: [AVCaptureDevice]!;
     var captureSession: AVCaptureSession!;
@@ -47,13 +55,21 @@ class QCAppDelegate: NSObject, NSApplicationDelegate {
         
         let deviceMenu = NSMenu();
         var deviceIndex = 0;
+
+        // Here we need to keep track of the current device (if selected) in order to keep it checked in the menu
+        var currentdevice = self.devices[defaultDeviceIndex]
+        if(self.captureSession != nil) {
+            currentdevice = (self.captureSession.inputs[0] as! AVCaptureDeviceInput).device
+        }
+        self.selectedDeviceIndex = defaultDeviceIndex
         
         for device in self.devices {
             let deviceMenuItem = NSMenuItem(title: device.localizedName, action: #selector(deviceMenuChanged), keyEquivalent: "")
             deviceMenuItem.target = self;
             deviceMenuItem.representedObject = deviceIndex;
-            if (deviceIndex == defaultDeviceIndex) {
+            if (device == currentdevice) {
                 deviceMenuItem.state = NSControl.StateValue.on;
+                self.selectedDeviceIndex = deviceIndex
             }
             if (deviceIndex < 9) {
                 deviceMenuItem.keyEquivalent = String(deviceIndex + 1);
@@ -187,6 +203,7 @@ class QCAppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         detectVideoDevices();
         startCaptureWithVideoDevice(defaultDevice: defaultDeviceIndex);
+        usb.delegate = self
     }
     
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {

--- a/QCamera/QCAppDelegate.swift
+++ b/QCamera/QCAppDelegate.swift
@@ -82,11 +82,18 @@ class QCAppDelegate: NSObject, NSApplicationDelegate, QCUsbWatcherDelegate {
     
     func startCaptureWithVideoDevice(defaultDevice: Int) {
         NSLog("Starting capture with device index %d", defaultDevice);
+        let device: AVCaptureDevice = self.devices[defaultDevice];
+        
         if (captureSession != nil) {
+            
+            // if we are "restarting" a session but the device is the same exit early
+            let currentdevice = (self.captureSession.inputs[0] as! AVCaptureDeviceInput).device
+            guard currentdevice != device else { return }
+            
             captureSession.stopRunning();
         }
         captureSession = AVCaptureSession();
-        let device: AVCaptureDevice = self.devices[defaultDevice];
+        
         do {
             let input: AVCaptureDeviceInput = try AVCaptureDeviceInput(device: device);
             self.captureSession.addInput(input);

--- a/QCamera/QCUsbWatcher.swift
+++ b/QCamera/QCUsbWatcher.swift
@@ -1,0 +1,69 @@
+//
+//  QCUsbWatcher.swift
+//  Quick Camera
+//
+//  Created by Ross Beazley on 07/08/2020.
+//  Copyright © 2020 Simon Guest. All rights reserved.
+//
+import IOKit
+import IOKit.usb
+import IOKit.usb.IOUSBLib
+public protocol QCUsbWatcherDelegate: class {
+    func deviceCountChanged()
+}
+
+public class QCUsbWatcher {
+    public weak var delegate: QCUsbWatcherDelegate?
+    private let notificationPort = IONotificationPortCreate(kIOMasterPortDefault)
+    private var addedIterator: io_iterator_t = 0
+    private var removedIterator: io_iterator_t = 0
+    
+    public init() {
+        func handleNotification(instance: UnsafeMutableRawPointer?, _ iterator: io_iterator_t) {
+            let watcher = Unmanaged<QCUsbWatcher>.fromOpaque(instance!).takeUnretainedValue()
+            while case let device = IOIteratorNext(iterator), device != IO_OBJECT_NULL {
+                
+                //give the OS a bit of time to finish setting up capture devices
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    watcher.delegate?.deviceCountChanged()
+                }
+                IOObjectRelease(device)
+            }
+        }
+    
+        let query = IOServiceMatching(kIOUSBDeviceClassName)
+        let opaqueSelf = Unmanaged.passUnretained(self).toOpaque()
+        
+        // Watch for connected devices.
+        IOServiceAddMatchingNotification(
+            notificationPort, kIOMatchedNotification, query,
+            handleNotification, opaqueSelf, &addedIterator)
+        consumeInitialUSBEvents(addedIterator)
+
+        // Watch for disconnected devices.
+        IOServiceAddMatchingNotification(
+            notificationPort, kIOTerminatedNotification, query,
+            handleNotification, opaqueSelf, &removedIterator)
+        consumeInitialUSBEvents(removedIterator)
+        
+        // Add the notification to the main run loop to receive future updates.
+        CFRunLoopAddSource(
+            CFRunLoopGetMain(),
+            IONotificationPortGetRunLoopSource(notificationPort).takeUnretainedValue(),
+            .commonModes)
+    }
+
+    deinit {
+        IOObjectRelease(addedIterator)
+        IOObjectRelease(removedIterator)
+        IONotificationPortDestroy(notificationPort)
+    }
+    
+    fileprivate func consumeInitialUSBEvents(_ iterator: io_iterator_t) {
+        while case let device = IOIteratorNext(iterator), device != IO_OBJECT_NULL {
+            IOObjectRelease(device)
+        }
+    }
+}
+
+

--- a/Quick Camera.xcodeproj/project.pbxproj
+++ b/Quick Camera.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		F43D252B16BB508900CBC272 /* icon.icns in Resources */ = {isa = PBXBuildFile; fileRef = F43D252A16BB508900CBC272 /* icon.icns */; };
 		F4CBD39716B8CE5F003A4794 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4CBD39616B8CE5F003A4794 /* Cocoa.framework */; };
 		F4CBD3AD16B8CE5F003A4794 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = F4CBD3AB16B8CE5F003A4794 /* MainMenu.xib */; };
+		F952D6E324E15A6200EA786D /* QCUsbWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F952D6E224E15A6200EA786D /* QCUsbWatcher.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +29,7 @@
 		F4CBD39A16B8CE5F003A4794 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		F4CBD39B16B8CE5F003A4794 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		F4CBD3AC16B8CE5F003A4794 /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = en.lproj/MainMenu.xib; sourceTree = "<group>"; };
+		F952D6E224E15A6200EA786D /* QCUsbWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QCUsbWatcher.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -90,6 +92,7 @@
 				87FF951F1E35B7CE0017DADB /* QCAppDelegate.swift */,
 				F43D252C16BB703100CBC272 /* QCamera.entitlements */,
 				F4CBD3AB16B8CE5F003A4794 /* MainMenu.xib */,
+				F952D6E224E15A6200EA786D /* QCUsbWatcher.swift */,
 			);
 			path = QCamera;
 			sourceTree = "<group>";
@@ -135,6 +138,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = F4CBD38A16B8CE5F003A4794;
@@ -165,6 +169,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				87FF95201E35B7CE0017DADB /* QCAppDelegate.swift in Sources */,
+				F952D6E324E15A6200EA786D /* QCUsbWatcher.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This is an implementation for https://github.com/simonguest/quick-camera/issues/3

I added one new file that integrates against IOKit, this will notify its delegate if any USB device is added or removed.

I altered the detectVideoDevices function, this will ensure the correct device is checked (ie not using the default index) when the usb device tree changes.

I altered the startCaptureWithVideoDevice to exit early if we are trying to start caputre for a device that is already being used.

If we unplug a device being used for a capture it should default to the default index device.